### PR TITLE
Add supporting for both SN32F24x and SN32F26x and other features

### DIFF
--- a/devices.ini
+++ b/devices.ini
@@ -1,0 +1,7 @@
+[Akko 3084 BT5]
+vid = 0x320F
+pid = 0x5013
+
+[Akko 3084 Bootloader]
+vid = 0x0c45
+pid = 0x7010

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ hidapi==0.9.0.post2
 macholib==1.14
 pefile==2019.4.18
 PyInstaller==3.4
-PyQt5==5.9.2
-sip==4.19.8
+PyQt5==5.15.2
+sip==5.0.0


### PR DESCRIPTION
1. add an "devices.ini" for supporting custom (vid,pid), add your keyboard vid,pid as a section of ini file
```
[Akko 3084 BT5]
vid = 0x320F
pid = 0x5013
```
2. add a radiobutton to select SN32F24x or SN32F26x, their ROM sizes are different.
3. add a radiobutton to select qmk_offset (0x200 or 0x00)